### PR TITLE
* add symbolic size support for external __malloc.

### DIFF
--- a/headers/gensym/defs.hpp
+++ b/headers/gensym/defs.hpp
@@ -14,6 +14,22 @@ using UIntData = unsigned long long int;
 using Fd = int;
 using status_t = unsigned short;
 
+// Forward declarations
+
+class SS;
+class PC;
+struct Value;
+struct IntV;
+struct SymV;
+struct LocV;
+struct SymLocV;
+struct FloatV;
+struct ShadowV;
+
+struct NullDerefException {
+  immer::box<SS> ss;
+};
+
 inline int vararg_id = -1;
 
 // Default bitwidth when creating integers or symbolic values
@@ -94,6 +110,8 @@ inline bool print_cov_detail = false;
 inline uint32_t print_detailed_log = 0;
 // The maximum size of symbolic location (used in memory read)
 inline unsigned int max_sym_array_size = 0;
+// The upper bound for the number of feasible symbolic size on malloc and memcpy
+inline unsigned int max_size_bound = 400;
 // Use simplification when constructing SymV values
 inline bool use_symv_simplify = false;
 

--- a/headers/gensym/ptree.hpp
+++ b/headers/gensym/ptree.hpp
@@ -59,7 +59,7 @@ public:
     auto it = ptreemap.find(ssid);
     assert(it != ptreemap.end());
     PTreeNodePtr old_ptr = it->second;
-    assert(!old_ptr->has_task);
+    //assert(!old_ptr->has_task);
     assert(!old_ptr->left);
     assert(!old_ptr->right);
     PTreeNodePtr new_ptr = new PTreeNode(old_ptr, ssid);
@@ -69,6 +69,10 @@ public:
     old_ptr->left = new_ptr;
     old_ptr->right = forked_ptr;
     old_ptr->ssid = 0;
+    if (old_ptr->has_task) {
+      new_ptr->task = std::move(old_ptr->task);
+      new_ptr->has_task = true;
+    }
     return forked_ptr->ssid;
   }
   void remove(uint64_t ssid) {

--- a/headers/gensym/smt_checker.hpp
+++ b/headers/gensym/smt_checker.hpp
@@ -370,7 +370,7 @@ public:
     if (use_cons_indep) resolve_indep_uf(pc.uf, e, conds, false);
     else conds.insert(pc.conds.begin(), pc.conds.end());
     UIntData data = 0;
-    solver_result result;
+    solver_result result = unsat;
     auto m = query_model(conds);
     if (m != nullptr) result = sat;
     return std::make_pair(result == sat, result == sat ? self()->eval_model(m, e) : 0);
@@ -460,7 +460,7 @@ inline bool check_pc(PC pc) {
   return result == solver_result::sat;
 }
 
-inline void check_pc_to_file(SS& state) {
+inline void check_pc_to_file(const SS& state) {
   auto start = steady_clock::now();
   checker_manager.get_checker().generate_test(std::move(state));
   auto end = steady_clock::now();

--- a/headers/gensym/thread_pool.hpp
+++ b/headers/gensym/thread_pool.hpp
@@ -30,6 +30,7 @@ using TaskFun = std::function<std::monostate()>;
 inline void ptree_add_task(uint64_t ssid, const TaskFun& f);
 
 inline bool ptree_pop_task(TaskFun& task);
+inline void check_pc_to_file(const SS& state);
 
 struct Task {
   TaskFun f;
@@ -138,7 +139,12 @@ public:
       }
       if (!paused && get) {
         //std::cout << "thread " << std::this_thread::get_id() << " is running; " << running_tasks_num() << "\n";
-        task.f();
+        try {
+          task.f();
+        } catch (NullDerefException e) {
+          //std::cout << "Warning: throwing an exception; generating a test case\n";
+          check_pc_to_file(e.ss.get());
+        }
         //std::cout << "thread " << std::this_thread::get_id() << " finished\n";
         tasks_num_total--;
       } else {

--- a/headers/gensym/value_ops.hpp
+++ b/headers/gensym/value_ops.hpp
@@ -824,11 +824,12 @@ inline PtrVal int_op_2(iOP op, const PtrVal& v1, const PtrVal& v2) {
     auto bw = bw1;
     if ((sym1 && iOP::op_ite == sym1->rator) && (sym2 && iOP::op_ite == sym2->rator) && ((*sym1)[0] == (*sym2)[0])) {
       return ite((*sym1)[0], int_op_2(op, (*sym1)[1], (*sym2)[1]), int_op_2(op, (*sym1)[2], (*sym2)[2]));
-    } else if (sym1 && iOP::op_ite == sym1->rator) {
+    }
+    /*else if (sym1 && iOP::op_ite == sym1->rator) {
       return ite((*sym1)[0], int_op_2(op, (*sym1)[1], v2), int_op_2(op, (*sym1)[2], v2));
     } else if (sym2 && iOP::op_ite == sym2->rator) {
       return ite((*sym2)[0], int_op_2(op, v1, (*sym2)[1]), int_op_2(op, v1, (*sym2)[2]));
-    }
+    }*/
     switch (op) {
       case iOP::op_eq: case iOP::op_neq: case iOP::op_uge:
       case iOP::op_sge: case iOP::op_ugt: case iOP::op_sgt:


### PR DESCRIPTION
* add symbolic dest, src, size support for external __llvm_memcpy
* add symbolic pointer support for SS::update
* add pc constraint when using symlocstrategy=one
* add bufferoverflow exception
* fix bug in get_sat_value
* disble ite rewriting in int_op_2 to avoid expression size explosion