### PR TITLE
lame fix

### DIFF
--- a/benchmarks/wasm/even_odd.wat
+++ b/benchmarks/wasm/even_odd.wat
@@ -24,12 +24,8 @@
     i32.add
     call 0)
   (func (;2;) (type 1) (result i32)
-    i32.const 0
+    i32.const 13
     call 1)
   (start 2)
-  (table (;0;) 1 1 funcref)
   (memory (;0;) 16)
-  (export "memory" (memory 0))
-  (export "is_even" (func 0))
-  (export "is_odd" (func 1))
-  (export "real_main" (func 2)))
+)

--- a/src/test/scala/genwasym/TestEval.scala
+++ b/src/test/scala/genwasym/TestEval.scala
@@ -93,8 +93,8 @@ class TestEval extends FunSuite {
   test("start") { testFile("./benchmarks/wasm/start.wat") }
   test("fact") { testFile("./benchmarks/wasm/fact.wat", None, Some(120)) }
   test("loop") { testFile("./benchmarks/wasm/loop.wat", None, Some(10)) }
-  // test("even-odd") { testFile("./benchmarks/wasm/even_odd.wat", None, Some(1)) }
-  // test("return") { testFile("./benchmarks/wasm/return.wat", None, None) }
+  test("even-odd") { testFile("./benchmarks/wasm/even_odd.wat", None, Some(1)) }
+  test("return") { testFile("./benchmarks/wasm/return.wat", None, None) }
 
   // Parser works, but the memory issue remains
   // test("btree") { testFile("./benchmarks/wasm/btree/2o1u-no-label-for-real.wat") }


### PR DESCRIPTION
Just throw another parameter :(

I guess we might need three continuations to express the control unless we can create the continuation when we visit a function.

- continuation to the start (I think only loop has this)
- fall thru continuation (eg: rest of `loop`, stuff after `block`)
- continuation to the end of function (this cannot not be shadowed by new continuation created by `block`, so it can't be on the trail