### PR TITLE
Smaller jump table

### DIFF
--- a/src/main/scala/wasm/MiniWasm.scala
+++ b/src/main/scala/wasm/MiniWasm.scala
@@ -304,7 +304,7 @@ object Evaluator {
           eval(rest, retStack.take(ty.out.size) ++ newStack, frame, kont, trail, ret)
         // We push newK on the trail since function creates a new block to escape
         // (more or less like `return`)
-        eval(body, List(), newFrame, newK, newK :: trail, 0)
+        eval(body, List(), newFrame, newK, List(newK), 0)
       case Call(f) if frame.module.funcs(f).isInstanceOf[Import] =>
         frame.module.funcs(f) match {
           case Import("console", "log", _) =>


### PR DESCRIPTION
I think we have an invariant that `ret` is always smaller than the size of `trail`, and this PR utilize this invariant to minimize `trail`'s size. Intuitively, trail represent a **local** jump table in current calling frame.

- Note, this is only for readability, and there's no space optimization involved since `trail` still needs to be caught by `newK`.